### PR TITLE
解除pillow限制

### DIFF
--- a/query_resource_points/query_resource_points.py
+++ b/query_resource_points/query_resource_points.py
@@ -18,6 +18,7 @@ header = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, l
 FILE_PATH = os.path.dirname(__file__)
 
 MAP_PATH = os.path.join(FILE_PATH,"icon","map_icon.jpg")
+Image.MAX_IMAGE_PIXELS = None
 
 
 # 这3个常量放在up_map()函数里更新


### PR DESCRIPTION
由于地图文件过大，地图更新时可能会触发图片最大尺寸限制
PIL.Image.DecompressionBombError: Image size (268435456 pixels) exceeds limit of 178956970 pixels,