### PR TITLE
fix gacha conflict

### DIFF
--- a/gacha/pool_data.py
+++ b/gacha/pool_data.py
@@ -221,8 +221,11 @@ async def init_pool_list():
     logger.info(f"正在更新卡池数据")
     data = await get_url_data(POOL_API)
     data = json.loads(data.decode("utf-8"))
-    for d in data["data"]["list"]:
-
+    pool_name_list = []
+    for d in reversed((data["data"]["list"])):
+        if str(d['gacha_name']) in pool_name_list:
+            continue
+        pool_name_list.append(str(d['gacha_name']))
         pool_name = str(d['gacha_name'])
         pool_url = f"https://webstatic.mihoyo.com/hk4e/gacha_info/cn_gf01/{d['gacha_id']}/zh-cn.json"
         pool_data = await get_url_data(pool_url)


### PR DESCRIPTION
目前的判断会导致开新池子的时候卡池里面同时有两个池子的角色，我加进来的是优先取新的，也就是提前抽新池子。如果不想提前抽新池子把 reversed() 去掉就好